### PR TITLE
Add before/after hooks to run custom actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.pyc
 adhan.log
 .settings
+before-hooks.d/*.sh
+after-hooks.d/*.sh

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This projects uses a python script which automatically calculates [adhan](https:
 Run this command:
 
 ```bash
-$ python /home/pi/adhan/updateAzaanTimers.py --lat <YOUR_LAT> --lng <YOUR_LNG> --method <METHOD>
+$ /home/pi/adhan/updateAzaanTimers.py --lat <YOUR_LAT> --lng <YOUR_LNG> --method <METHOD>
 ```
 
 Replace the arguments above with your location information and calculation method:
@@ -34,12 +34,12 @@ If everythig worked, your output will look something like this:
 14:11
 16:30
 17:53
-51 5 * * * omxplayer -o local /home/pi/adhan/Adhan-fajr.mp3 > /dev/null 2>&1 # rpiAdhanClockJob
-52 11 * * * omxplayer -o local /home/pi/adhan/Adhan-Makkah.mp3 > /dev/null 2>&1 # rpiAdhanClockJob
-11 14 * * * omxplayer -o local /home/pi/adhan/Adhan-Makkah.mp3 > /dev/null 2>&1 # rpiAdhanClockJob
-30 16 * * * omxplayer -o local /home/pi/adhan/Adhan-Makkah.mp3 > /dev/null 2>&1 # rpiAdhanClockJob
-53 17 * * * omxplayer -o local /home/pi/adhan/Adhan-Makkah.mp3 > /dev/null 2>&1 # rpiAdhanClockJob
-0 1 * * * python /home/pi/adhan/updateAzaanTimers.py >> /home/pi/adhan/adhan.log 2>&1 # rpiAdhanClockJob
+51 5 * * * /home/pi/adhan/playAzaan.sh /home/pi/adhan/Adhan-fajr.mp3 0 # rpiAdhanClockJob
+52 11 * * * /home/pi/adhan/playAzaan.sh /home/pi/adhan/Adhan-Madinah.mp3 0 # rpiAdhanClockJob
+11 14 * * * /home/pi/adhan/playAzaan.sh /home/pi/adhan/Adhan-Madinah.mp3 0 # rpiAdhanClockJob
+30 16 * * * /home/pi/adhan/playAzaan.sh /home/pi/adhan/Adhan-Madinah.mp3 0 # rpiAdhanClockJob
+53 17 * * * /home/pi/adhan/playAzaan.sh /home/pi/adhan/Adhan-Madinah.mp3 0 # rpiAdhanClockJob
+0 1 * * * /home/pi/adhan/updateAzaanTimers.py >> /home/pi/adhan/adhan.log 2>&1 # rpiAdhanClockJob
 @monthly truncate -s 0 /home/pi/adhan/adhan.log 2>&1 # rpiAdhanClockJob
 Script execution finished at: 2017-01-06 21:22:31.512667
 ```
@@ -56,11 +56,47 @@ There are 2 additional arguments that are optional, you can set them in the firs
 further runs: `--fajr-azaan-volume` and `azaan-volume`. You can control the volume of the Azaan
 by supplying numbers in millibels. To get more information on how to select the values, run the command with `-h`.
 
+## Configuring custom actions before/after adhan
+
+Sometimes it is needed to run custom commands either before, after or before
+and after playing adhan. For example, if you have
+[Quran playing continuously](https://github.com/LintangWisesa/RPi_QuranSpeaker),
+you would want to pause and resume the playback. Another example, is to set your
+status on a social network, or a calendar, to block/unblock the Internet
+using [pi.hole rules](https://docs.pi-hole.net/), ... etc.
+
+You can easily do this by adding scripts in the following directories:
+- `before-hooks.d`: Scripts to run before adhan playback
+- `after-hooks.d`: Scripts to run after adhan playback
+
+### Example:
+To pause/resume Quran playback if using the
+[RPi_QuranSpeaker](https://github.com/LintangWisesa/RPi_QuranSpeaker) project, place
+the following in 2 new files under the above 2 directories:
+
+```bash
+# before-hooks.d/01-pause-quran-speaker.sh
+#!/usr/bin/env bash
+/home/pi/RPi_QuranSpeaker/pauser.py pause
+```
+
+```bash
+# after-hooks.d/01-resume-quran-speaker.sh
+#!/usr/bin/env bash
+/home/pi/RPi_QuranSpeaker/pauser.py resume
+```
+
+Do not forget to make the scripts executable:
+```bash
+chmod u+x ./before-hooks.d/01-pause-quran-speaker.sh
+chmod u+x ./after-hooks.d/01-resume-quran-speaker.sh
+```
+
 ## Tips:
 1. You can see your currently scheduled jobs by running `crontab -l`
 2. The output of the job that runs at 1am every night is being captured in `/home/pi/adhan/adhan.log`. This way you can keep track of all successful runs and any potential issues. This file will be truncated at midnight on the forst day of each month. To view the output type `$ cat /home/pi/adhan/adhan.log`
 
-### Credits
+## Credits
 I have made modifications / bug fixes but I've used the following as starting point:
 * Python code to calculate adhan times: http://praytimes.org/code/ 
 * Basic code to turn the above into an adhan clock: http://randomconsultant.blogspot.co.uk/2013/07/turn-your-raspberry-pi-into-azaanprayer.html

--- a/after-hooks.d/00-example.sh
+++ b/after-hooks.d/00-example.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# This file must be executable, to make it as such, run the following:
+#   chmod u+x <this-file>
+# It can also be written in any language so long as a valid shebang (#!) is used as above
+echo "Placeholder for an after hook"

--- a/before-hooks.d/00-example.sh
+++ b/before-hooks.d/00-example.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# This file must be executable, to make it as such, run the following:
+#   chmod u+x <this-file>
+# It can also be written in any language so long as a valid shebang (#!) is used as above
+echo "Placeholder for a before hook"

--- a/playAzaan.sh
+++ b/playAzaan.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+if [ $# -lt 1 ]; then
+  echo "USAGE: $0 <azaan-audio-path> [<volume>]"
+  exit 1
+fi
+
+audio_path="$1"
+vol=${2:-0}
+root_dir=`dirname $0`
+
+# Run before hooks
+for hook in $root_dir/before-hooks.d/*; do
+    echo "Running before hook: $hook"
+    $hook
+done
+
+# Play Azaan audio
+omxplayer --vol $vol -o local $audio_path
+
+# Run after hooks
+for hook in $root_dir/after-hooks.d/*; do
+    echo "Running after hook: $hook"
+    $hook
+done

--- a/updateAzaanTimers.py
+++ b/updateAzaanTimers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import datetime
 import time
@@ -118,9 +118,9 @@ utcOffset = -(time.timezone/3600)
 isDst = time.localtime().tm_isdst
 
 now = datetime.datetime.now()
-strPlayFajrAzaanMP3Command = 'omxplayer --vol {} -o local {}/Adhan-fajr.mp3 > /dev/null 2>&1'.format(fajr_azaan_vol, root_dir)
-strPlayAzaanMP3Command = 'omxplayer --vol {} -o local {}/Adhan-Madinah.mp3 > /dev/null 2>&1'.format(azaan_vol, root_dir)
-strUpdateCommand = 'python {}/updateAzaanTimers.py >> {}/adhan.log 2>&1'.format(root_dir, root_dir)
+strPlayFajrAzaanMP3Command = '{}/playAzaan.sh {}/Adhan-fajr.mp3 {}'.format(root_dir, root_dir, fajr_azaan_vol)
+strPlayAzaanMP3Command = '{}/playAzaan.sh {}/Adhan-Madinah.mp3 {}'.format(root_dir, root_dir, azaan_vol)
+strUpdateCommand = '{}/updateAzaanTimers.py >> {}/adhan.log 2>&1'.format(root_dir, root_dir)
 strClearLogsCommand = 'truncate -s 0 {}/adhan.log 2>&1'.format(root_dir)
 strJobComment = 'rpiAdhanClockJob'
 


### PR DESCRIPTION
Sometimes it is needed to run custom commands either before, after or before and after playing adhan. For example, if you have
[Quran playing continuously](https://github.com/LintangWisesa/RPi_QuranSpeaker), you would want to pause and resume the playback. Another example, is to set your status on a social network, or a calendar, to block/unblock the Internet using [pi.hole rules](https://docs.pi-hole.net/), ... etc.

You can easily do this by adding scripts in the following directories:
- `before-hooks.d`: Scripts to run before adhan playback
- `after-hooks.d`: Scripts to run after adhan playback

### Example:
To pause/resume Quran playback if using the [RPi_QuranSpeaker](https://github.com/LintangWisesa/RPi_QuranSpeaker) project, place the following in a new file (e.g. `01-pause-quran-speaker.sh`) under the above 2 directories:

```bash
#!/usr/bin/env bash
/home/pi/RPi_QuranSpeaker/pauser.py
```

Do not forget to make the scripts executable:
```bash
chmod u+x ./{before,after}-hooks.d/01-pause-quran-speaker.sh
```
